### PR TITLE
Added event handler for check boxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .venv
 randomizer/__pycache__
-randomizer/ui_elements/__pycache__
+randomizer/*/__pycache__

--- a/randomizer/constants.py
+++ b/randomizer/constants.py
@@ -106,6 +106,6 @@ class Hints(str, Enum):
     CLASS_MODE = (
         "Set the mode for randomizing classes.\nCombat - all units guaranteed "
         "to have offensive capabilities\nCombat/Staff - all units are either "
-        "offesnive or staff only wielders\nAll - Re-roll all classes "
+        "offensive or staff only wielders\nAll - Re-roll all classes "
         "(potential soft lock)"
     )

--- a/randomizer/controllers/__init__.py
+++ b/randomizer/controllers/__init__.py
@@ -1,0 +1,3 @@
+""" Import everything from this directory """
+
+from .check_box_controller import *

--- a/randomizer/controllers/check_box_controller.py
+++ b/randomizer/controllers/check_box_controller.py
@@ -1,0 +1,7 @@
+""" Check box controllers """
+
+def handler(*elements):
+    """ Toggle the state of the ui elements """
+    for element in elements:
+        element.setDisabled(element.isEnabled())
+        

--- a/randomizer/randomizer.py
+++ b/randomizer/randomizer.py
@@ -23,8 +23,8 @@ class Randomizer(QWidget):
         self.setWindowIcon(QIcon(f"{DEFAULT_CONFIG_PATH}/randomizer.ico"))
 
         self.labels = label.create_labels(self)
-        self.check_boxes = check_box.create_check_boxes()
         self.spin_boxes = spinbox.create_spin_boxes(self)
+        self.check_boxes = check_box.create_check_boxes(self.spin_boxes)
         self.combo_boxes = combo_box.create_combo_boxes()
         self.buttons = button.create_buttons(self)
         self.file_browsers = browse.create_file_browsers(self)

--- a/randomizer/ui_elements/check_box.py
+++ b/randomizer/ui_elements/check_box.py
@@ -3,9 +3,10 @@
 from PyQt5.QtWidgets import QCheckBox
 
 from constants import Hints
+from controllers import check_box_controller
 
 
-def create_check_boxes():
+def create_check_boxes(spin_boxes):
     """ Init and return a dict of check boxes """
     boxes = [
         "pb_enabled",
@@ -26,22 +27,47 @@ def create_check_boxes():
 
     mapping = {box: QCheckBox("Enabled") for box in boxes}
 
+    for check_box in mapping.values():
+        check_box.setChecked(True)
+
     mapping["pb_enabled"].setToolTip(Hints.PLAYABLE_BASES)
+    mapping["pb_enabled"].stateChanged.connect(lambda: check_box_controller.handler(spin_boxes["pb_min"], spin_boxes["pb_max"]))
+
     mapping["bb_enabled"].setToolTip(Hints.BOSS_BASES)
+    mapping["bb_enabled"].stateChanged.connect(lambda: check_box_controller.handler(spin_boxes["bb_min"], spin_boxes["bb_max"]))
+
     mapping["ob_enabled"].setToolTip(Hints.OTHER_BASES)
+    mapping["ob_enabled"].stateChanged.connect(lambda: check_box_controller.handler(spin_boxes["ob_min"], spin_boxes["ob_max"]))
+
     mapping["cb_enabled"].setToolTip(Hints.CLASS_BASES)
+    mapping["cb_enabled"].stateChanged.connect(lambda: check_box_controller.handler(spin_boxes["cb_min"], spin_boxes["cb_max"]))
 
     mapping["pg_enabled"].setToolTip(Hints.PLAYABLE_GROWTHS)
+    mapping["pg_enabled"].stateChanged.connect(lambda: check_box_controller.handler(spin_boxes["pg_min"], spin_boxes["pg_max"]))
+
     mapping["bg_enabled"].setToolTip(Hints.BOSS_GROWTHS)
+    mapping["bg_enabled"].stateChanged.connect(lambda: check_box_controller.handler(spin_boxes["bg_min"], spin_boxes["bg_max"]))
+
     mapping["og_enabled"].setToolTip(Hints.OTHER_GROWTHS)
+    mapping["og_enabled"].stateChanged.connect(lambda: check_box_controller.handler(spin_boxes["og_min"], spin_boxes["og_max"]))
 
     mapping["mpb_enabled"].setToolTip(Hints.MOD_PLAYABLE_BASES)
+    mapping["mpb_enabled"].stateChanged.connect(lambda: check_box_controller.handler(spin_boxes["pb_mod"]))
+
     mapping["mbb_enabled"].setToolTip(Hints.MOD_BOSS_BASES)
+    mapping["mbb_enabled"].stateChanged.connect(lambda: check_box_controller.handler(spin_boxes["bb_mod"]))
+
     mapping["mob_enabled"].setToolTip(Hints.MOD_OTHER_BASES)
+    mapping["mob_enabled"].stateChanged.connect(lambda: check_box_controller.handler(spin_boxes["ob_mod"]))
 
     mapping["mpg_enabled"].setToolTip(Hints.MOD_PLAYABLE_GROWTHS)
+    mapping["mpg_enabled"].stateChanged.connect(lambda: check_box_controller.handler(spin_boxes["pg_mod"]))
+
     mapping["mbg_enabled"].setToolTip(Hints.MOD_BOSS_GROWTHS)
+    mapping["mbg_enabled"].stateChanged.connect(lambda: check_box_controller.handler(spin_boxes["bg_mod"]))
+
     mapping["mog_enabled"].setToolTip(Hints.MOD_OTHER_GROWTHS)
+    mapping["mog_enabled"].stateChanged.connect(lambda: check_box_controller.handler(spin_boxes["og_mod"]))
 
     mapping["master_seal_enabled"].setToolTip(Hints.FORCE_MASTER_SEAL)
 


### PR DESCRIPTION
# What/Why
The randomizer needs an event handler for checking the check boxes so that the GUI elements will reflect the state of the check box. The event handler will toggle the state of the spin boxes associated with that check box when you toggle the state of that check box.

## Other things that changed
 - I fixed a spelling error on one of the ToolTips
 - I wildcarded `__pycache__` in the `.gitignore`
 - 