### PR TITLE
Bug fixes

### DIFF
--- a/config/FE7.yml
+++ b/config/FE7.yml
@@ -1944,9 +1944,9 @@ items:
       - 0xf
       - 0x10
       - 0x12
-      - 0x1e
     lance:
       - 0x1a
+      - 0x1e
       - 0x95
     axe:
       - 0x24

--- a/config/FE7.yml
+++ b/config/FE7.yml
@@ -1272,6 +1272,7 @@ classes:
       kind: boss
       item_pos:
         - 0xCDCAB4
+        - 0xCDCAB5
         - 0xCDCE44
         - 0xCDCE45
         - 0xCDCC84

--- a/config/FE7.yml
+++ b/config/FE7.yml
@@ -61,6 +61,7 @@ classes:
     offsets:
       ability4: 0x2b # Ability4 is used for making items dropable
       dropable_bitmask: 0x8
+      animation: 0x25
 
     # Character IDs whose classes are in the ban list but need reclassing to a
     # promoted class

--- a/config/FE7.yml
+++ b/config/FE7.yml
@@ -560,6 +560,7 @@ classes:
         - 0xCDA011
         - 0xCDA361
         - 0xCDA451
+        - 0xCDB869
       kind: playable
       item_pos:
         - 0xCD141C
@@ -596,6 +597,9 @@ classes:
         - 0xCD1535
         - 0xCD613D
         - 0xCD602D
+        - 0xCD7255
+        - 0xCDB939
+        - 0xCD60CD
       kind: playable
       item_pos:
         - 0xCD06B0
@@ -614,6 +618,10 @@ classes:
         - 0xCD247D
         - 0xCD614D
         - 0xCD603D
+        - 0xCD7265
+        - 0xCDB949
+        - 0xCDB969
+        - 0xCD60DD
       kind: playable
       item_pos:
         - 0xCC6BF9
@@ -628,6 +636,7 @@ classes:
         - 0xCE0505
         - 0xCD24FD
         - 0xCD257D
+        - 0xCDB9C9
       kind: playable
       item_pos:
         - 0xCDC7BC

--- a/config/FE7.yml
+++ b/config/FE7.yml
@@ -1761,6 +1761,7 @@ items:
     description: 0x2
     use_screen: 0x4
     type: 0x7
+    rank: 0x1c
     icon: 0x1d
     use: 0x1e
     ability3: 0xa # The ability that contains locks
@@ -1837,13 +1838,16 @@ items:
         new_location: 0xb8d900
         item_location: 0xBE3570
   prf:
-    9: 0x1    # Rapier     -> E rank sword
-    10: 0x2   # Mani Katti -> E rank sword
-    60: 0x3b  # Forblaze   -> A rank anima
-    141: 0x1f # Wolf Beil  -> E rank axe
-    132: 0x4  # Durandal   -> A rank sword
-    133: 0x21 # Armads     -> A rank axe
-    140: 0x4  # Sol Katti  -> A rank sword
+    e:
+      - 9    # Rapier     -> E rank sword
+      - 10   # Mani Katti -> E rank sword
+      - 141 # Wolr Beil  -> E rank axe
+    s:
+      - 60  # Forblaze   -> A rank anima
+      - 132  # Durandal   -> A rank sword
+      - 133 # Armads     -> A rank axe
+      - 140  # Sol Katti  -> A rank sword
+      - 142  # Ereshkigal -> A rank dark
 
   types:
     0x0: sword

--- a/config/FE7.yml
+++ b/config/FE7.yml
@@ -78,6 +78,15 @@ classes:
         0xCD5028: 18
         0xCD502A: 18
 
+      # Locations of branch statements to overwrite
+      noops:
+        - 0x7d9f6
+        - 0x7d9f7
+        - 0x7d9fe
+        - 0x7d9ff
+        - 0x7da06
+        - 0x7da07
+
       # Position of generic Druid holding Gespenst. Used to replace with Teodor
       generic_druid_pos: 0xCE0054
 

--- a/config/FE7.yml
+++ b/config/FE7.yml
@@ -715,6 +715,8 @@ classes:
       item_pos:
         - 0xCCF784
         - 0xCCF7A4
+      extra_item_pos:
+        - 0xCCF787
     Karla:
       id:
         - 0x37

--- a/randomizer/rom_editors/fe7/character_editor.py
+++ b/randomizer/rom_editors/fe7/character_editor.py
@@ -32,6 +32,7 @@ class FE7CharacterEditor(CharacterEditor):
         self._handle_thief_override()
         self._handle_flyer_overrides()
         self._handle_teodor_override()
+        self._handle_karla_override()
         self._give_final_bosses_s_ranks()
         self._make_weapons_dropable()
         self._remove_hardcoded_animations()
@@ -83,6 +84,18 @@ class FE7CharacterEditor(CharacterEditor):
             "overrides"
         ]["generic_druid_pos"]
         self._rom_data[generic_druid_pos] = teodor_id
+
+    def _handle_karla_override(self):
+        """
+        Karla only appears on Hector mode if Bartre is a level 5 Warrior. If Bartre
+        is randomized to any other class than fighter, then it is impossible for
+        Karla to even appear. So let's overwrite the branch statments that will skip
+        loading Karla in with NO-OP statements so that she always spawns in.
+        """
+        for address in self._game_config["classes"]["character_stats"]["overrides"][
+            "noops"
+        ]:
+            self._rom_data[address] = 0
 
     def _handle_flyer_overrides(self):
         """

--- a/randomizer/rom_editors/fe7/character_editor.py
+++ b/randomizer/rom_editors/fe7/character_editor.py
@@ -34,6 +34,7 @@ class FE7CharacterEditor(CharacterEditor):
         self._handle_teodor_override()
         self._give_final_bosses_s_ranks()
         self._make_weapons_dropable()
+        self._remove_hardcoded_animations()
 
     def _handle_serra_override(self):
         """
@@ -128,3 +129,18 @@ class FE7CharacterEditor(CharacterEditor):
                 self._rom_data[first + offset]
                 | character_stats["offsets"]["dropable_bitmask"]
             )
+
+    def _remove_hardcoded_animations(self):
+        """
+        Some characters are given hardcoded animations. Let's remove them
+        """
+        characters = self._game_config["classes"]["characters"]
+        first = self._game_config["classes"]["character_stats"]["first"]
+        total_bytes = self._game_config["classes"]["character_stats"]["total_bytes"]
+        offset = self._game_config["classes"]["character_stats"]["offsets"]["animation"]
+        for character in characters:
+            if characters[character]["kind"] not in self._filters:
+                for _id in characters[character]["id"]:
+                    location = first + (_id * total_bytes) + offset
+                    self._rom_data[location] = 0
+                    self._rom_data[location + 1] = 0

--- a/randomizer/rom_editors/fe7/character_editor.py
+++ b/randomizer/rom_editors/fe7/character_editor.py
@@ -27,9 +27,9 @@ class FE7CharacterEditor(CharacterEditor):
             ]
 
     def handle_overrides(self):
-        """ Set the matthew and serra overrides """
+        """ Do all FE7-specific overrides """
         self._handle_serra_override()
-        self._handle_matthew_override()
+        self._handle_thief_override()
         self._handle_flyer_overrides()
         self._handle_teodor_override()
         self._give_final_bosses_s_ranks()
@@ -51,11 +51,14 @@ class FE7CharacterEditor(CharacterEditor):
             serra_res_pos = first_class + (serra_id * total_bytes) + res_offset
             self._rom_data[serra_res_pos] = 0
 
-    def _handle_matthew_override(self):
+    def _handle_thief_override(self):
         """
         Although a thief is not required to complete chapter 6, starting Matthew
         with an additional door key and chest key will allow the player to get
-        all loot
+        all loot.
+
+        Additionally, if Legault does not have chest keys, he will immediately leave
+        the Dragon's Gate chapter. So we should give him chest keys as well
         """
         chest_key_id = self._game_config["items"]["chest_key_id"]
         door_key_id = self._game_config["items"]["door_key_id"]
@@ -64,6 +67,11 @@ class FE7CharacterEditor(CharacterEditor):
         ]:
             self._rom_data[item_pos] = chest_key_id
             self._rom_data[item_pos + 1] = door_key_id
+
+        for item_pos in self._game_config["classes"]["characters"]["Legault"][
+            "extra_item_pos"
+        ]:
+            self._rom_data[item_pos] = chest_key_id
 
     def _handle_teodor_override(self):
         """

--- a/randomizer/rom_editors/fe7/item_editor.py
+++ b/randomizer/rom_editors/fe7/item_editor.py
@@ -10,16 +10,16 @@ class FE7ItemEditor(ItemEditor):
 
     def handle_prf(self):
         """
-        Zero out item locks
+        Zero out item locks and set them to E or S rank
         """
-        for item in self._game_config["items"]["prf"]:
-            first_item = self._game_config["items"]["first"]
-            total_bytes = self._game_config["items"]["total_bytes"]
-            self._rom_data[
-                self._game_config["items"]["offsets"]["ability3"]
-                + (item * total_bytes)
-                + first_item
-            ] = 0
+        for rank in {"e", "s"}:
+            rank_value = 1 if rank == "e" else 251
+            for item in self._game_config["items"]["prf"][rank]:
+                first_item = self._game_config["items"]["first"]
+                total_bytes = self._game_config["items"]["total_bytes"]
+                item_loc = (item * total_bytes) + first_item
+                self._zero_out_locks(item_loc)
+                self._set_rank(item_loc, rank_value)
 
     def handle_s_rank(self):
         """ Give all bosses in final chapter s rank weapons """
@@ -32,3 +32,14 @@ class FE7ItemEditor(ItemEditor):
                 item_type = self._get_item_type(item)
                 rand = randint(0, len(s_ranks[item_type]) - 1)
                 self._rom_data[item_loc] = s_ranks[item_type][rand]
+
+    def _zero_out_locks(self, item_loc):
+        """ Remove all item locks on the item """
+        # Remove the character locks on items
+        offset = self._game_config["items"]["offsets"]["ability3"]
+        self._rom_data[item_loc + offset] = 0
+
+    def _set_rank(self, item_loc, rank_value):
+        """ Set rank of the item """
+        offset = self._game_config["items"]["offsets"]["rank"]
+        self._rom_data[item_loc + offset] = rank_value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,4 +97,4 @@ def create_game_config(character_data):
 @pytest.fixture(name="rom_data")
 def create_rom_data():
     """ Create fake rom_data for testing """
-    return bytearray(b"0123456789abcdefghijklmnop")
+    return bytearray(b"0123456789abcdefghijklmnopqrstuvwxyz")

--- a/tests/rom_editors/test_fe7_character_editor.py
+++ b/tests/rom_editors/test_fe7_character_editor.py
@@ -20,6 +20,7 @@ def create_char_editor(game_config, rom_data):
     game_config["classes"]["characters"] = {
         "Serra": {"id": [0], "kind": "playable"},
         "Matthew": {"id": [0], "extra_item_pos": [1], "kind": "playable"},
+        "Legault": {"id": [0], "extra_item_pos": [3], "kind": "playable"},
         "Teodor": {
             "id": [0],
             "kind": "boss",
@@ -55,11 +56,12 @@ def test_handle_serra_override(char_editor):
     assert char_editor.rom_data[17] == 0
 
 
-def test_handle_matthew_override(char_editor):
-    """ Test the handle_matthew_override method """
-    char_editor._handle_matthew_override()
+def test_handle_thief_override(char_editor):
+    """ Test the handle_thief_override method """
+    char_editor._handle_thief_override()
     assert char_editor.rom_data[1] == 100
     assert char_editor.rom_data[2] == 101
+    assert char_editor.rom_data[3] == 100
 
 
 def test_handle_teodor_override(char_editor):

--- a/tests/rom_editors/test_fe7_character_editor.py
+++ b/tests/rom_editors/test_fe7_character_editor.py
@@ -18,10 +18,13 @@ def create_char_editor(game_config, rom_data):
         "class1": {"promotion_pos": 0, "promotion_id": 15}
     }
     game_config["classes"]["characters"] = {
-        "Serra": {"id": [0]},
-        "Matthew": {"extra_item_pos": [1]},
-        "Teodor": {"id": [150]},
-        "boss1": {"s_rank_locations": [1], "id": [6]},
+        "Serra": {"id": [0], "kind": "playable"},
+        "Matthew": {"id": [0], "extra_item_pos": [1], "kind": "playable"},
+        "Teodor": {
+            "id": [0],
+            "kind": "boss",
+        },
+        "boss1": {"id": [0], "s_rank_locations": [1], "kind": "boss"},
     }
     game_config["classes"]["character_stats"]["overrides"] = {
         "generic_druid_pos": 3,
@@ -32,6 +35,7 @@ def create_char_editor(game_config, rom_data):
     game_config["classes"]["character_stats"]["offsets"] = {
         "ability4": 9,
         "dropable_bitmask": 16,
+        "animation": 19,
     }
     game_config["items"]["chest_key_id"] = 100
     game_config["items"]["door_key_id"] = 101
@@ -61,7 +65,7 @@ def test_handle_matthew_override(char_editor):
 def test_handle_teodor_override(char_editor):
     """ Test the handl_ teodor_override_method """
     char_editor._handle_teodor_override()
-    assert char_editor.rom_data[3] == 150
+    assert char_editor.rom_data[3] == 0
 
 
 def test_handle_flyer_overrides(char_editor):
@@ -81,13 +85,20 @@ def test_give_final_bosses_s_ranks(char_editor):
     ] = 5
     char_editor._rom_data[14] = 1
     char_editor._give_final_bosses_s_ranks()
-    assert char_editor.rom_data[8] == 255
+    assert char_editor.rom_data[2] == 255
 
 
 def test_make_weapons_dropable(char_editor):
     """ Test the make_weapons_dropable method """
     char_editor._make_weapons_dropable()
     assert char_editor.rom_data[18] == 121
+
+
+def test_remove_hardcoded_animations(char_editor):
+    """ Test the _remove_hardcoded_animations method """
+    char_editor._remove_hardcoded_animations()
+    assert char_editor.rom_data[19] == 0
+    assert char_editor.rom_data[20] == 0
 
 
 def test_handle_overrides(char_editor):
@@ -100,6 +111,8 @@ def test_handle_overrides(char_editor):
     assert char_editor.rom_data[17] == 0
     assert char_editor.rom_data[1] == 100
     assert char_editor.rom_data[2] == 101
-    assert char_editor.rom_data[3] == 150
+    assert char_editor.rom_data[3] == 0
     assert char_editor.rom_data[4] == 200
     assert char_editor.rom_data[18] == 121
+    assert char_editor.rom_data[19] == 0
+    assert char_editor.rom_data[20] == 0

--- a/tests/rom_editors/test_fe7_character_editor.py
+++ b/tests/rom_editors/test_fe7_character_editor.py
@@ -30,6 +30,7 @@ def create_char_editor(game_config, rom_data):
     game_config["classes"]["character_stats"]["overrides"] = {
         "generic_druid_pos": 3,
         "flyers": {4: 200},
+        "noops": [21],
     }
     game_config["classes"]["character_stats"]["final_bosses"] = ["boss1"]
     game_config["classes"]["character_stats"]["dropable_weapon_characters"] = [9]
@@ -65,9 +66,15 @@ def test_handle_thief_override(char_editor):
 
 
 def test_handle_teodor_override(char_editor):
-    """ Test the handl_ teodor_override_method """
+    """ Test the handle_teodor_override_method """
     char_editor._handle_teodor_override()
     assert char_editor.rom_data[3] == 0
+
+
+def test_handle_karla_override(char_editor):
+    """ Test the _handle_karla_override method """
+    char_editor._handle_karla_override()
+    assert char_editor.rom_data[21] == 0
 
 
 def test_handle_flyer_overrides(char_editor):
@@ -118,3 +125,4 @@ def test_handle_overrides(char_editor):
     assert char_editor.rom_data[18] == 121
     assert char_editor.rom_data[19] == 0
     assert char_editor.rom_data[20] == 0
+    assert char_editor.rom_data[21] == 0

--- a/tests/rom_editors/test_fe7_item_editor.py
+++ b/tests/rom_editors/test_fe7_item_editor.py
@@ -10,10 +10,11 @@ from rom_editors.fe7.item_editor import FE7ItemEditor
 @pytest.fixture(name="item_edit")
 def create_item_editor(rom_data, game_config):
     """ Create an item editor object with FE7 specific items for testing """
-    game_config["items"]["prf"] = [0]
+    game_config["items"]["prf"] = {"e": [0], "s": [1]}
     game_config["items"]["offsets"]["ability3"] = 7
+    game_config["items"]["offsets"]["rank"] = 8
 
-    game_config["items"]["flux_weapon_lvl_pos"] = 8
+    game_config["items"]["flux_weapon_lvl_pos"] = 9
     game_config["items"]["s"] = {"dark": [2]}
     game_config["classes"]["character_stats"]["final_bosses"] = ["boss1"]
     game_config["classes"]["characters"] = {"boss1": {"s_rank_locations": [9]}}
@@ -24,6 +25,7 @@ def test_handle_prf(item_edit):
     """ Test the handle_prf method """
     item_edit.handle_prf()
     assert item_edit.rom_data[7] == 0
+    assert item_edit.rom_data[9] == 251
 
 
 def test_handle_s_rank(item_edit):
@@ -31,5 +33,4 @@ def test_handle_s_rank(item_edit):
     with mock.patch.object(item_edit, "_get_item_type", return_value="dark"):
         item_edit.handle_s_rank()
 
-    assert item_edit.rom_data[8] == 1
     assert item_edit.rom_data[9] == 2

--- a/tests/rom_editors/test_init.py
+++ b/tests/rom_editors/test_init.py
@@ -3,8 +3,8 @@
 from constants import FEVersions
 from rom_editors import (
     create_character_editor,
-    create_stat_randomizer,
     create_stat_modifier,
+    create_stat_randomizer,
     create_prom_editor,
     VERSION_MAP,
 )

--- a/tests/rom_editors/test_stat_editor.py
+++ b/tests/rom_editors/test_stat_editor.py
@@ -71,4 +71,4 @@ def test_modify_character_stats(stat_mod):
         stat_mod.modify_character_stats(stat_type)
 
     assert stat_mod.rom_data[3] == 46
-    assert stat_mod.rom_data[4] == 62
+    assert stat_mod.rom_data[4] == 152

--- a/tests/rom_editors/test_stat_editor.py
+++ b/tests/rom_editors/test_stat_editor.py
@@ -71,4 +71,4 @@ def test_modify_character_stats(stat_mod):
         stat_mod.modify_character_stats(stat_type)
 
     assert stat_mod.rom_data[3] == 46
-    assert stat_mod.rom_data[4] == 42
+    assert stat_mod.rom_data[4] == 62


### PR DESCRIPTION
# Bug Fixes
 - Allow Karla to appear no matter what
     - Karla only appears if Bartre is a level 5 Warrior
     - If Bartre is randomized to a class other than Fighter or Warrior, it will be impossible to recruit Karla
     - This version makes it to where Karla will always appear no matter what state Bartre is in
 - Axereavers are no longer considered C-rank swords. They're now used as C-rank lances
 - Legault is now given a key when randomized. If he has no way to open chests, his AI will attempt to leave the chapter. This can cause Legault to leave on turn 1. So start him with chest keys and he won't immediately leave.
 - Fix various places where characters were not randomized
 - Fix a bug where one of Denning's weapons was not randomized
 - Fix a bug where some characters didn't have battle animations
     - Some characters have hard-coded battle animations
     - I removed them so that the game will have a valid battle animation for each class
 - Fix a bug with S rank weapons
     - Armads, Durandal, Ereshkigal, Forblaze and Sol Katti could be used by anyone
     - Now they're weapon levels are set to S rank